### PR TITLE
Update module path for slashdevops transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ratelimiter
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/p2p-b2b/ratelimiter.svg)](https://pkg.go.dev/github.com/p2p-b2b/ratelimiter)
+[![Go Reference](https://pkg.go.dev/badge/github.com/slashdevops/ratelimiter.svg)](https://pkg.go.dev/github.com/slashdevops/ratelimiter)
 
 ## Introduction
 
@@ -25,7 +25,7 @@ For advanced use cases, you can provide your own storage backend by implementing
 ## Installation
 
 ```bash
-go get github.com/p2p-b2b/ratelimiter
+go get github.com/slashdevops/ratelimiter
 ```
 
 ## Core Concepts
@@ -44,7 +44,7 @@ import (
   "fmt"
   "time"
 
-  "github.com/p2p-b2b/ratelimiter"
+  "github.com/slashdevops/ratelimiter"
   "golang.org/x/time/rate"
 )
 
@@ -103,7 +103,7 @@ import (
   "strings"
   "time"
 
-  "github.com/p2p-b2b/ratelimiter"
+  "github.com/slashdevops/ratelimiter"
   "golang.org/x/time/rate"
 )
 

--- a/examples/key/main.go
+++ b/examples/key/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/p2p-b2b/ratelimiter"
+	"github.com/slashdevops/ratelimiter"
 	"golang.org/x/time/rate"
 )
 

--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/p2p-b2b/ratelimiter"
+	"github.com/slashdevops/ratelimiter"
 	"golang.org/x/time/rate"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/p2p-b2b/ratelimiter
+module github.com/slashdevops/ratelimiter
 
 go 1.24.2
 


### PR DESCRIPTION
Updates repository references after the transfer from `p2p-b2b` to `slashdevops`.

Summary:
- Update the Go module path to `github.com/slashdevops/ratelimiter`
- Refresh README badge, install command, and import examples
- Update example program imports to the new module path

Validation:
- `go test ./...`