### PR TITLE
fix!: isolate token buckets per key and manage limiter lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,36 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/slashdevops/ratelimiter.svg)](https://pkg.go.dev/github.com/slashdevops/ratelimiter)
 
-## Introduction
+A flexible, goroutine-safe, **per-key** rate limiter for Go, built as a thin
+manager around the token-bucket implementation in
+[`golang.org/x/time/rate`](https://pkg.go.dev/golang.org/x/time/rate).
 
-`ratelimiter` is a flexible and extensible rate limiter library for Go, built as a wrapper around the standard `golang.org/x/time/rate` package. It utilizes the token bucket algorithm to control the rate of operations, making it suitable for scenarios like API request limiting, resource access control, and preventing abuse.
+Each key (a user ID, API key, or IP address) gets its **own independent token
+bucket**, so one client exhausting its budget never affects another. Limiters
+are created lazily on first use and automatically evicted after they have been
+idle for a configurable duration.
 
-The library allows creating rate limiters specific to different keys (e.g., user IDs, IP addresses) that can be safely shared across multiple goroutines. It includes an in-memory storage backend by default and features automatic cleanup of limiters that haven't been used for a configurable duration.
-
-For advanced use cases, you can provide your own storage backend by implementing the `Storage` interface or even define custom rate-limiting logic by implementing the `Limiter` interface.
+> **New to token buckets?** See [docs/TOKEN_BUCKET.md](docs/TOKEN_BUCKET.md) for
+> a thorough, from-scratch explanation of the algorithm, how to choose `limit`
+> and `burst`, and how the HTTP rate-limit headers work.
 
 ## Features
 
-- **Token Bucket Algorithm:** Based on the robust `golang.org/x/time/rate` implementation.
-- **Key-Based Limiting:** Create and manage separate limiters for different identifiers (e.g., IP addresses, user IDs).
-- **Goroutine-Safe:** Designed for concurrent use.
-- **In-Memory Storage:** Comes with a built-in `InMemoryStorage` for easy setup.
-- **Automatic Cleanup:** Unused limiters are automatically removed from storage after a specified duration to conserve resources.
-- **Extensible:**
-  - Implement the `Storage` interface for custom persistence (e.g., Redis, Memcached).
-  - Implement the `Limiter` interface for custom rate-limiting strategies.
-- **Middleware Example:** Includes a practical example for integrating with `net/http` handlers.
+- **Per-key isolation** — a separate token bucket per identifier; keys never
+  share a budget.
+- **Token bucket algorithm** — sustained average rate plus configurable bursts,
+  backed by the battle-tested `golang.org/x/time/rate`.
+- **Goroutine-safe** — designed for concurrent use; key creation is atomic (no
+  duplicate limiters under races).
+- **Automatic idle eviction** — a single background goroutine removes limiters
+  that have not been used for `deleteAfter`; active keys are kept alive. Stop it
+  with `Close()`.
+- **Type-safe & generic** — `Storage[K, V]` and `BucketLimiter[K]` use Go
+  generics (Go 1.25+).
+- **Extensible** — implement the `Storage` interface for a custom in-process
+  store, or the `Limiter` interface for a custom algorithm.
+- **HTTP middleware example** — with accurate `Retry-After` and `RateLimit-*`
+  response headers.
 
 ## Installation
 
@@ -28,171 +39,135 @@ For advanced use cases, you can provide your own storage backend by implementing
 go get github.com/slashdevops/ratelimiter
 ```
 
-## Core Concepts
+Requires Go 1.25 or newer.
 
-- **`Limiter` Interface:** Defines the basic contract for any rate limiter, primarily the `Allow()` method. The standard `golang.org/x/time/rate.Limiter` satisfies this interface.
-- **`Storage` Interface:** Defines methods (`Store`, `Load`, `Delete`) for storing and retrieving limiter instances associated with keys.
-- **`InMemoryStorage`:** A thread-safe, map-based implementation of the `Storage` interface.
-- **`BucketLimiter`:** The main orchestrator. It uses a `Limiter` (like `rate.Limiter`) as a template, a `Storage` backend, and manages the creation, retrieval, and automatic cleanup of key-specific limiters.
-
-## Basic Example
+## Quick start
 
 ```go
 package main
 
 import (
-  "fmt"
-  "time"
+	"fmt"
+	"time"
 
-  "github.com/slashdevops/ratelimiter"
-  "golang.org/x/time/rate"
+	"github.com/slashdevops/ratelimiter"
+	"golang.org/x/time/rate"
 )
 
 func main() {
-  // 1. Create a storage system (in-memory is provided)
-  storage := ratelimiter.NewInMemoryStorage()
+	// A store that keeps one Limiter per key.
+	storage := ratelimiter.NewInMemoryStorage[string, ratelimiter.Limiter]()
 
-  // 2. Define the base rate limit (e.g., 5 requests per second with a burst of 10)
-  baseRate := rate.Limit(5)
-  burstSize := 10
-  baseLimiter := rate.NewLimiter(baseRate, burstSize)
+	// A factory that builds an independent bucket for each new key:
+	// 5 requests/second sustained, absorbing bursts of up to 10.
+	newLimiter := ratelimiter.NewRateLimiterFunc(rate.Limit(5), 10)
 
-  // 3. Configure the BucketLimiter
-  //    Limiters unused for 1 minute will be automatically removed.
-  cleanupInterval := 1 * time.Minute
-  bucketLimiter := ratelimiter.NewBucketLimiter(baseLimiter, cleanupInterval, storage)
+	// The manager. Limiters idle for 1 minute are evicted.
+	manager := ratelimiter.NewBucketLimiter(newLimiter, time.Minute, storage)
+	defer manager.Close() // stop the background eviction goroutine
 
-  // 4. Get or create a limiter for a specific key (e.g., user ID or IP)
-  userID := "user-123"
-  userLimiter := bucketLimiter.GetOrAdd(userID)
-
-  // 5. Check if the operation is allowed
-  if userLimiter.Allow() {
-    fmt.Println("Operation allowed for", userID)
-    // ... perform the rate-limited action ...
-  } else {
-    fmt.Println("Rate limit exceeded for", userID)
-  }
-
-  // Example: Simulate multiple requests
-  for i := 0; i < 15; i++ {
-    if bucketLimiter.GetOrAdd(userID).Allow() {
-      fmt.Printf("Request %d allowed\n", i+1)
-    } else {
-      fmt.Printf("Request %d blocked\n", i+1)
-    }
-    time.Sleep(100 * time.Millisecond) // Simulate some delay
-  }
+	// Each key has its own bucket.
+	if manager.GetOrAdd("user-123").Allow() {
+		fmt.Println("allowed")
+	} else {
+		fmt.Println("rate limited")
+	}
 }
-
 ```
 
-## Middleware Example
+## Core concepts
 
-See [examples](examples/) for more usage examples, including the HTTP middleware.
+| Type / func                        | Role                                                                       |
+|------------------------------------|----------------------------------------------------------------------------|
+| `Limiter`                          | Minimal interface (`Allow`, `Wait`, `Burst`). `*rate.Limiter` satisfies it. |
+| `Storage[K, V]`                    | Pluggable, concurrency-safe store for per-key limiters.                    |
+| `InMemoryStorage[K, V]`            | Default `sync.Map`-backed store.                                            |
+| `BucketLimiter[K]`                 | Manager: hands out one `Limiter` per key, handles creation and eviction.  |
+| `NewRateLimiterFunc(limit, burst)` | Convenience factory for the common `*rate.Limiter` case.                    |
 
-Middleware example:
+### `limit` and `burst`
+
+- **`limit`** (`rate.Limit`) — sustained refill rate in **tokens per second**.
+  Use `rate.Every(d)` for "one every `d`", or `rate.Inf` for unlimited.
+- **`burst`** (`int`) — bucket **capacity**: the largest number of requests
+  allowed in a single instant.
+
+See [docs/TOKEN_BUCKET.md](docs/TOKEN_BUCKET.md#choosing-parameters) for guidance
+on choosing values.
+
+## `Allow` vs. `Wait`
 
 ```go
-package main
+lim := manager.GetOrAdd(key)
 
-import (
-  "flag"
-  "fmt"
-  "net/http"
-  "strings"
-  "time"
-
-  "github.com/slashdevops/ratelimiter"
-  "golang.org/x/time/rate"
-)
-
-// Middleware is a function that wraps an http.Handler to provide additional functionality
-type Middleware func(http.Handler) http.Handler
-
-// ThenFunc wraps an http.HandlerFunc with a middleware
-func (m Middleware) ThenFunc(h http.HandlerFunc) http.Handler {
-  return m(http.HandlerFunc(h))
+// Non-blocking: drop work when over the limit (e.g. HTTP 429).
+if !lim.Allow() {
+	// reject
 }
 
-// IPRateLimiter is a middleware that limits the number of requests from a single IP address
-func IPRateLimiter(limiter *ratelimiter.BucketLimiter) Middleware {
-  return func(next http.Handler) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-      ip := strings.Split(r.RemoteAddr, ":")[0]
-
-      lim := limiter.GetOrAdd(ip)
-      if !lim.Allow() {
-        http.Error(w, fmt.Sprintf("too many requests from ip address %s", ip), http.StatusTooManyRequests)
-        return
-      }
-
-      next.ServeHTTP(w, r)
-    })
-  }
+// Blocking: shape work by waiting for a token (pass a ctx with a deadline).
+if err := lim.Wait(ctx); err != nil {
+	// ctx cancelled/expired
 }
+```
 
-func main() {
-  limit := flag.Int("limit", 2, "Rate limit (requests per second)")
-  burst := flag.Int("burst", 1, "Burst size")
-  deleteAfter := flag.Duration("deleteAfter", 5*time.Second, "Duration after which the limiter will be deleted if not used")
-  numberOfRequests := flag.Int("numberOfRequests", 30, "Number of requests to send")
-  waitBetweenRequests := flag.Duration("waitBetweenRequests", 100*time.Millisecond, "Wait time between requests")
+## HTTP middleware
 
-  flag.Parse()
+The [`examples/middleware`](examples/middleware/main.go) program limits requests
+per client IP and sets standard response headers:
 
-  // Create a storage system
-  storage := ratelimiter.NewInMemoryStorage()
+- `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset` (IETF draft names,
+  plus legacy `X-RateLimit-*`).
+- `Retry-After` on `429`, computed from the actual reservation delay.
 
-  // Create a base rate limiter
-  baseLimiter := rate.NewLimiter(rate.Limit(float64(*limit)), *burst)
+It also extracts the client IP with `net.SplitHostPort`, so it is correct for
+both IPv4 and IPv6.
 
-  // Create a bucket limiter with a deleteAfter duration of 5 seconds
-  bucketLimiter := ratelimiter.NewBucketLimiter(baseLimiter, *deleteAfter, storage)
+```bash
+go run ./examples/middleware -limit 2 -burst 1
+```
 
-  // Create a new HTTP server
-  mux := http.NewServeMux()
+See [`examples/key`](examples/key/main.go) for a minimal, dependency-free demo of
+per-key isolation and bucket refill over time:
 
-  // Register the rate limiting middleware
-  mux.Handle("GET /", IPRateLimiter(bucketLimiter).ThenFunc(func(w http.ResponseWriter, r *http.Request) {
-    fmt.Fprintln(w, "Hello, world without limit!")
-  }))
+```bash
+go run ./examples/key -limit 1 -burst 3
+```
 
-  // go routine doing request
-  go func() {
-    // wait until the server is up
-    fmt.Println("Waiting for server to start...")
-    time.Sleep(2 * time.Second)
+## Custom storage
 
-    for range *numberOfRequests {
+Implement `Storage[K, V]` to back the manager with your own in-process store —
+for example a size-bounded LRU to cap memory instead of (or in addition to)
+time-based eviction. Implementations must be safe for concurrent use, and
+`LoadOrStore` must be atomic.
 
-      resp, err := http.Get("http://localhost:8080/")
-      if err != nil {
-        fmt.Println("Error:", err)
-        continue
-      }
-      resp.Body.Close()
-
-      if resp.StatusCode == http.StatusOK {
-        fmt.Println("Request allowed")
-      } else {
-        fmt.Println("Request rejected:", resp.Status)
-      }
-      time.Sleep(*waitBetweenRequests) // Wait between requests
-    }
-
-    fmt.Println()
-    fmt.Println("Finished sending requests, press Ctrl+C to stop the server")
-  }()
-
-  // Start the server
-  fmt.Println("Starting server on :8080...")
-  if err := http.ListenAndServe(":8080", mux); err != nil {
-    fmt.Println("Error starting server:", err)
-  }
+```go
+type Storage[K comparable, V any] interface {
+	Store(key K, value V)
+	Load(key K) (value V, ok bool)
+	LoadOrStore(key K, value V) (actual V, loaded bool)
+	Delete(key K)
+	Range(f func(key K, value V) bool)
 }
+```
+
+## Scope: single-process only
+
+Token state lives in memory inside each `*rate.Limiter`, so this library
+enforces limits **within one process**. Running N instances behind a load
+balancer yields an effective global limit of up to N × `limit`. Global,
+cross-instance limiting requires a distributed algorithm (e.g. a Redis script)
+and is out of scope. The `Storage` interface is for custom *in-process* stores,
+not for synchronizing token state across machines. See
+[docs/TOKEN_BUCKET.md](docs/TOKEN_BUCKET.md#single-process-vs-distributed).
+
+## Testing
+
+```bash
+go test -race ./...
+go test -bench . -benchmem ./...
 ```
 
 ## License
 
-This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ idle for a configurable duration.
 > **New to token buckets?** See [docs/TOKEN_BUCKET.md](docs/TOKEN_BUCKET.md) for
 > a thorough, from-scratch explanation of the algorithm, how to choose `limit`
 > and `burst`, and how the HTTP rate-limit headers work.
+>
+> **Upgrading from an earlier version?** See
+> [docs/MIGRATION.md](docs/MIGRATION.md) for a before/after guide to the breaking
+> API changes.
 
 ## Features
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,45 @@
+package ratelimiter
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// BenchmarkGetOrAdd_Existing measures the hot path: fetching an existing key.
+func BenchmarkGetOrAdd_Existing(b *testing.B) {
+	storage := NewInMemoryStorage[string, Limiter]()
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(1000), 100), time.Minute, storage)
+	b.Cleanup(func() { _ = bl.Close() })
+	bl.GetOrAdd("hot")
+
+	b.ReportAllocs()
+	for b.Loop() {
+		bl.GetOrAdd("hot")
+	}
+}
+
+// BenchmarkGetOrAdd_Parallel measures contended access across many keys.
+func BenchmarkGetOrAdd_Parallel(b *testing.B) {
+	storage := NewInMemoryStorage[string, Limiter]()
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(1000), 100), time.Minute, storage)
+	b.Cleanup(func() { _ = bl.Close() })
+
+	keys := make([]string, 256)
+	for i := range keys {
+		keys[i] = "key-" + strconv.Itoa(i)
+		bl.GetOrAdd(keys[i])
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			bl.GetOrAdd(keys[i%len(keys)]).Allow()
+			i++
+		}
+	})
+}

--- a/bucket_limiter.go
+++ b/bucket_limiter.go
@@ -1,77 +1,193 @@
-// The rate limiter is a token bucket algorithm
-// https://en.wikipedia.org/wiki/Token_bucket
 package ratelimiter
 
 import (
-	"context"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// BucketLimiter is a rate limiter that uses a bucket algorithm
-// It allows a certain number of requests in a given time frame
-// and then limits the requests to a certain rate
-// It uses a storage system to store the state of the limiter
-// and a deleteAfter duration to remove the limiter after a certain time
-// It implements the Limiter interface
-// and uses the Storage interface to store the state of the limiter
-type BucketLimiter struct {
+// defaultSweepDivisor controls how often the background eviction goroutine runs
+// relative to deleteAfter when no explicit interval is configured. An idle
+// entry is therefore removed somewhere between deleteAfter and
+// deleteAfter*(1 + 1/divisor) after its last use.
+const defaultSweepDivisor = 2
+
+// BucketLimiter is a goroutine-safe manager that hands out an independent
+// token-bucket [Limiter] per key (for example a user ID or IP address).
+//
+// Each distinct key receives its own [Limiter], produced by the newLimiter
+// factory, so consuming one key's budget never affects another. Limiters are
+// created lazily on first access and evicted after they have been idle (not
+// accessed through GetOrAdd) for deleteAfter. Eviction runs in a single
+// background goroutine started by [NewBucketLimiter] and stopped by
+// [BucketLimiter.Close].
+//
+// The zero value is not usable; construct one with [NewBucketLimiter].
+type BucketLimiter[K comparable] struct {
+	newLimiter  func() Limiter
 	deleteAfter time.Duration
-	storage     Storage
-	limiter     Limiter
+	interval    time.Duration
+	now         func() time.Time
+	storage     Storage[K, Limiter]
+
+	// access tracks the last-use time (unix nanoseconds) per key so the
+	// sweeper can evict genuinely idle entries. It is kept separate from
+	// storage so that custom Storage backends only ever hold Limiter values.
+	access sync.Map // K -> *atomic.Int64
+
+	stop      chan struct{}
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
-// NewBucketLimiter creates a new BucketLimiter
-// with the given limiter, deleteAfter duration and storage system
-func NewBucketLimiter(limiter Limiter, deleteAfter time.Duration, storage Storage) *BucketLimiter {
-	return &BucketLimiter{
-		deleteAfter: deleteAfter,
-		storage:     storage,
-		limiter:     limiter,
+// Option configures a [BucketLimiter] at construction time.
+type Option func(*config)
+
+type config struct {
+	now      func() time.Time
+	interval time.Duration
+}
+
+// WithClock overrides the time source used for idle tracking and eviction.
+// It is primarily useful in tests to make eviction deterministic.
+func WithClock(now func() time.Time) Option {
+	return func(c *config) {
+		if now != nil {
+			c.now = now
+		}
 	}
 }
 
-// GetOrAdd gets the limiter for the given key from the storage
-// If the limiter does not exist, it creates a new one
-// and stores it in the storage
-// It returns the limiter for the given key
-// It also starts a goroutine to delete the limiter after the deleteAfter duration
-func (b *BucketLimiter) GetOrAdd(key string) (value Limiter) {
+// WithSweepInterval overrides how often the background eviction goroutine runs.
+// When unset, it defaults to deleteAfter/2. Ignored when deleteAfter <= 0.
+func WithSweepInterval(d time.Duration) Option {
+	return func(c *config) {
+		if d > 0 {
+			c.interval = d
+		}
+	}
+}
+
+// NewBucketLimiter creates a [BucketLimiter].
+//
+//   - newLimiter is called once per new key to build that key's independent
+//     [Limiter]. Use [NewRateLimiterFunc] for the common *rate.Limiter case.
+//   - deleteAfter is the idle duration after which an unused key is evicted.
+//     A value <= 0 disables eviction (limiters live until [BucketLimiter.Remove]
+//     or [BucketLimiter.Close]); prefer this only for bounded key spaces.
+//   - storage is the backing store, commonly
+//     ratelimiter.NewInMemoryStorage[K, ratelimiter.Limiter]().
+//
+// When eviction is enabled a background goroutine is started; call
+// [BucketLimiter.Close] to stop it and release resources.
+func NewBucketLimiter[K comparable](
+	newLimiter func() Limiter,
+	deleteAfter time.Duration,
+	storage Storage[K, Limiter],
+	opts ...Option,
+) *BucketLimiter[K] {
+	cfg := config{now: time.Now}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	interval := cfg.interval
+	if interval <= 0 {
+		interval = deleteAfter / defaultSweepDivisor
+		if interval <= 0 {
+			interval = deleteAfter
+		}
+	}
+
+	b := &BucketLimiter[K]{
+		newLimiter:  newLimiter,
+		deleteAfter: deleteAfter,
+		interval:    interval,
+		now:         cfg.now,
+		storage:     storage,
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+	}
+
+	if deleteAfter > 0 {
+		go b.sweepLoop()
+	} else {
+		close(b.done)
+	}
+
+	return b
+}
+
+// GetOrAdd returns the [Limiter] for key, creating and storing a new one via
+// the newLimiter factory if none exists yet. Concurrent callers racing on the
+// same new key all receive the same instance. Every call refreshes the key's
+// idle timer.
+func (b *BucketLimiter[K]) GetOrAdd(key K) Limiter {
 	limiter, ok := b.storage.Load(key)
 	if !ok {
-		limiter = NewBucketLimiter(b.limiter, b.deleteAfter, b.storage)
-		b.storage.Store(key, limiter)
-
-		go func() {
-			time.Sleep(b.deleteAfter)
-			b.storage.Delete(key)
-		}()
+		// LoadOrStore makes creation atomic: if another goroutine wins the
+		// race, we discard our fresh limiter and use the stored one.
+		limiter, _ = b.storage.LoadOrStore(key, b.newLimiter())
 	}
 
-	return limiter.(Limiter)
+	b.touch(key)
+	return limiter
 }
 
-// Remove removes the limiter for the given key from the storage
-func (b *BucketLimiter) Remove(key string) error {
-	b.storage.Delete(key)
+// touch records the current time as key's last-use time.
+func (b *BucketLimiter[K]) touch(key K) {
+	if b.deleteAfter <= 0 {
+		return
+	}
+	v, _ := b.access.LoadOrStore(key, new(atomic.Int64))
+	v.(*atomic.Int64).Store(b.now().UnixNano())
+}
 
+// Remove immediately deletes the limiter for key. A subsequent GetOrAdd
+// creates a fresh one.
+func (b *BucketLimiter[K]) Remove(key K) {
+	b.storage.Delete(key)
+	b.access.Delete(key)
+}
+
+// Close stops the background eviction goroutine and waits for it to exit. It is
+// safe to call multiple times and from multiple goroutines. After Close the
+// manager can still serve GetOrAdd, but idle entries will no longer be evicted
+// automatically.
+func (b *BucketLimiter[K]) Close() error {
+	b.closeOnce.Do(func() {
+		close(b.stop)
+	})
+	<-b.done
 	return nil
 }
 
-// Wait waits for the limiter to allow the request
-// It returns an error if the request is not allowed
-// It uses the Wait method of the limiter
-func (b *BucketLimiter) Wait(ctx context.Context) error {
-	return b.limiter.Wait(ctx)
+// sweepLoop periodically evicts entries idle for longer than deleteAfter.
+func (b *BucketLimiter[K]) sweepLoop() {
+	defer close(b.done)
+
+	ticker := time.NewTicker(b.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-b.stop:
+			return
+		case <-ticker.C:
+			b.evictIdle()
+		}
+	}
 }
 
-// Allow checks if the request is allowed by the limiter
-// It returns true if the request is allowed, false otherwise
-func (b *BucketLimiter) Allow() bool {
-	return b.limiter.Allow()
-}
-
-// Burst returns the burst size of the limiter
-// It returns the burst size of the limiter
-func (b *BucketLimiter) Burst() int {
-	return b.limiter.Burst()
+// evictIdle removes every key whose last use is older than deleteAfter.
+func (b *BucketLimiter[K]) evictIdle() {
+	cutoff := b.now().Add(-b.deleteAfter).UnixNano()
+	b.access.Range(func(k, v any) bool {
+		if v.(*atomic.Int64).Load() <= cutoff {
+			key := k.(K)
+			b.storage.Delete(key)
+			b.access.Delete(key)
+		}
+		return true
+	})
 }

--- a/bucket_limiter_test.go
+++ b/bucket_limiter_test.go
@@ -4,410 +4,267 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 )
 
-// Helper function to create a base limiter for tests
-func newTestBaseLimiter() *rate.Limiter {
-	return rate.NewLimiter(rate.Limit(10), 5) // 10 tokens/sec, burst 5
+// newStorage is a small helper for the common string-keyed store used by tests.
+func newStorage() *InMemoryStorage[string, Limiter] {
+	return NewInMemoryStorage[string, Limiter]()
 }
 
-// request simulates a request being processed
-func request(t testing.TB, who string) {
-	t.Helper()
+// TestNewBucketLimiter verifies the constructor wires its fields.
+func TestNewBucketLimiter(t *testing.T) {
+	storage := newStorage()
+	deleteAfter := 5 * time.Second
 
-	time.Sleep(500 * time.Millisecond)
-	_, err := fmt.Printf("Request from %s done\n", who)
-	if err != nil {
-		t.Errorf("Failed to print message: %v", err)
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(10), 5), deleteAfter, storage)
+	t.Cleanup(func() { _ = bl.Close() })
+
+	require.NotNil(t, bl)
+	assert.Equal(t, deleteAfter, bl.deleteAfter)
+	assert.Same(t, storage, bl.storage)
+}
+
+// TestBucketLimiter_PerKeyIsolation is the key regression test: distinct keys
+// MUST have independent token buckets.
+func TestBucketLimiter_PerKeyIsolation(t *testing.T) {
+	storage := newStorage()
+	// burst of 3, effectively no refill during the test window.
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(1), 3), time.Minute, storage)
+	t.Cleanup(func() { _ = bl.Close() })
+
+	a := bl.GetOrAdd("user-A")
+	for i := range 3 {
+		require.True(t, a.Allow(), "user-A request %d should be allowed", i+1)
+	}
+	assert.False(t, a.Allow(), "user-A should be exhausted after its burst")
+
+	// A completely separate key must still have a full, independent bucket.
+	b := bl.GetOrAdd("user-B")
+	allowed := 0
+	for range 3 {
+		if b.Allow() {
+			allowed++
+		}
+	}
+	assert.Equal(t, 3, allowed, "user-B must have its own bucket independent of user-A")
+}
+
+// TestBucketLimiter_GetOrAdd_New verifies a new key is created and stored.
+func TestBucketLimiter_GetOrAdd_New(t *testing.T) {
+	storage := newStorage()
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(10), 5), 100*time.Millisecond, storage)
+	t.Cleanup(func() { _ = bl.Close() })
+
+	limiter := bl.GetOrAdd("k")
+	require.NotNil(t, limiter)
+
+	stored, ok := storage.Load("k")
+	assert.True(t, ok)
+	assert.Same(t, limiter, stored)
+}
+
+// TestBucketLimiter_GetOrAdd_Existing verifies the same instance is returned.
+func TestBucketLimiter_GetOrAdd_Existing(t *testing.T) {
+	storage := newStorage()
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(10), 5), 5*time.Second, storage)
+	t.Cleanup(func() { _ = bl.Close() })
+
+	first := bl.GetOrAdd("k")
+	second := bl.GetOrAdd("k")
+	assert.Same(t, first, second, "existing key must return the same instance")
+}
+
+// TestBucketLimiter_EvictsIdle verifies idle keys are evicted, using a fake
+// clock so the assertion is deterministic instead of timing-dependent.
+func TestBucketLimiter_EvictsIdle(t *testing.T) {
+	storage := newStorage()
+
+	var nowNanos atomic.Int64
+	nowNanos.Store(time.Now().UnixNano())
+	clock := func() time.Time { return time.Unix(0, nowNanos.Load()) }
+
+	deleteAfter := time.Second
+	bl := NewBucketLimiter(
+		NewRateLimiterFunc(rate.Limit(10), 5),
+		deleteAfter,
+		storage,
+		WithClock(clock),
+		WithSweepInterval(5*time.Millisecond),
+	)
+	t.Cleanup(func() { _ = bl.Close() })
+
+	bl.GetOrAdd("k")
+	_, ok := storage.Load("k")
+	require.True(t, ok, "key should be present right after creation")
+
+	// Advance the clock well past the idle window; the sweeper must evict it.
+	nowNanos.Add(int64(2 * deleteAfter))
+
+	assert.Eventually(t, func() bool {
+		_, ok := storage.Load("k")
+		return !ok
+	}, time.Second, 5*time.Millisecond, "idle key should be evicted")
+}
+
+// TestBucketLimiter_AccessKeepsAlive verifies that continued use prevents
+// eviction (the "idle since last use" semantics).
+func TestBucketLimiter_AccessKeepsAlive(t *testing.T) {
+	storage := newStorage()
+
+	var nowNanos atomic.Int64
+	nowNanos.Store(time.Now().UnixNano())
+	clock := func() time.Time { return time.Unix(0, nowNanos.Load()) }
+
+	deleteAfter := time.Second
+	bl := NewBucketLimiter(
+		NewRateLimiterFunc(rate.Limit(10), 5),
+		deleteAfter,
+		storage,
+		WithClock(clock),
+		WithSweepInterval(5*time.Millisecond),
+	)
+	t.Cleanup(func() { _ = bl.Close() })
+
+	bl.GetOrAdd("k")
+
+	// Advance time but keep touching the key: it must survive several sweeps.
+	for i := range 5 {
+		nowNanos.Add(int64(deleteAfter / 2))
+		bl.GetOrAdd("k")
+		time.Sleep(10 * time.Millisecond) // let the sweeper run at least once
+		_, ok := storage.Load("k")
+		require.True(t, ok, "actively-used key must not be evicted (iteration %d)", i)
 	}
 }
 
-// TestNewBucketLimiter tests the constructor
-func TestNewBucketLimiter(t *testing.T) {
-	storage := NewInMemoryStorage()
-	baseLimiter := newTestBaseLimiter()
-	deleteAfter := 5 * time.Second
-
-	bl := NewBucketLimiter(baseLimiter, deleteAfter, storage) // Pass pointer to storage
-
-	assert.NotNil(t, bl, "BucketLimiter should not be nil")
-	assert.Equal(t, deleteAfter, bl.deleteAfter, "deleteAfter duration should match")
-	assert.Same(t, storage, bl.storage, "Storage should match") // Use assert.Same for pointer identity
-	assert.Equal(t, baseLimiter, bl.limiter, "Base limiter should match")
-}
-
-// TestBucketLimiter_GetOrAdd_New tests adding a new limiter
-func TestBucketLimiter_GetOrAdd_New(t *testing.T) {
-	storage := NewInMemoryStorage()
-	baseLimiter := newTestBaseLimiter()
-	deleteAfter := 100 * time.Millisecond // Short duration for testing cleanup
-	bl := NewBucketLimiter(baseLimiter, deleteAfter, storage)
-
-	key := "test-key-new"
-
-	// First call should create and return a new limiter
-	limiter1 := bl.GetOrAdd(key)
-	assert.NotNil(t, limiter1, "Returned limiter should not be nil")
-
-	// Check if it's stored
-	storedLimiter, ok := storage.Load(key)
-	assert.True(t, ok, "Limiter should be stored")
-	assert.Equal(t, limiter1, storedLimiter, "Returned limiter should be the one stored")
-}
-
-// TestBucketLimiter_GetOrAdd_Existing tests retrieving an existing limiter
-func TestBucketLimiter_GetOrAdd_Existing(t *testing.T) {
-	storage := NewInMemoryStorage()
-	baseLimiter := newTestBaseLimiter()
-	deleteAfter := 5 * time.Second
-	bl := NewBucketLimiter(baseLimiter, deleteAfter, storage)
-
-	key := "test-key-existing"
-
-	// Add it first
-	limiter1 := bl.GetOrAdd(key)
-	assert.NotNil(t, limiter1)
-
-	// Get it again
-	limiter2 := bl.GetOrAdd(key)
-	assert.NotNil(t, limiter2)
-	assert.Same(t, limiter1, limiter2, "Getting an existing key should return the same limiter instance")
-}
-
-// TestBucketLimiter_GetOrAdd_DeleteAfter tests automatic deletion
-func TestBucketLimiter_GetOrAdd_DeleteAfter(t *testing.T) {
-	storage := NewInMemoryStorage()
-	baseLimiter := newTestBaseLimiter()
-	deleteAfter := 50 * time.Millisecond // Very short duration
-	bl := NewBucketLimiter(baseLimiter, deleteAfter, storage)
-
-	key := "test-key-delete"
-
-	// Add the limiter
-	limiter1 := bl.GetOrAdd(key)
-	assert.NotNil(t, limiter1)
-
-	// Check it's there
-	_, ok := storage.Load(key)
-	assert.True(t, ok, "Limiter should be present initially")
-
-	// Wait longer than deleteAfter
-	time.Sleep(deleteAfter + 20*time.Millisecond)
-
-	// Check if it's deleted
-	_, ok = storage.Load(key)
-	assert.False(t, ok, "Limiter should be deleted after deleteAfter duration")
-
-	// Getting it again should create a new one
-	limiter2 := bl.GetOrAdd(key)
-	assert.NotNil(t, limiter2, "Should get a new limiter after deletion")
-	assert.NotSame(t, limiter1, limiter2, "Should be a different instance after deletion and re-creation")
-
-	// Check the new one is stored
-	_, ok = storage.Load(key)
-	assert.True(t, ok, "New limiter should be stored after re-creation")
-}
-
-// TestBucketLimiter_Remove tests manual removal
+// TestBucketLimiter_Remove verifies manual removal.
 func TestBucketLimiter_Remove(t *testing.T) {
-	storage := NewInMemoryStorage()
-	baseLimiter := newTestBaseLimiter()
-	deleteAfter := 5 * time.Second
-	bl := NewBucketLimiter(baseLimiter, deleteAfter, storage)
+	storage := newStorage()
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(10), 5), 5*time.Second, storage)
+	t.Cleanup(func() { _ = bl.Close() })
 
-	key := "test-key-remove"
+	bl.GetOrAdd("k")
+	_, ok := storage.Load("k")
+	require.True(t, ok)
 
-	// Add it
-	bl.GetOrAdd(key)
-	_, ok := storage.Load(key)
-	assert.True(t, ok, "Limiter should be present before removal")
-
-	// Remove it
-	err := bl.Remove(key)
-	assert.NoError(t, err, "Remove should not return an error")
-
-	// Check it's gone
-	_, ok = storage.Load(key)
-	assert.False(t, ok, "Limiter should be absent after removal")
+	bl.Remove("k")
+	_, ok = storage.Load("k")
+	assert.False(t, ok, "key should be gone after Remove")
 }
 
-// TestBucketLimiter_GetOrAdd_Concurrent tests concurrent access
+// TestBucketLimiter_Close verifies Close stops the sweeper and is idempotent.
+func TestBucketLimiter_Close(t *testing.T) {
+	storage := newStorage()
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(10), 5), time.Second, storage)
+
+	require.NoError(t, bl.Close())
+	require.NoError(t, bl.Close(), "Close must be idempotent")
+
+	// The manager still serves requests after Close.
+	assert.NotNil(t, bl.GetOrAdd("k"))
+}
+
+// TestBucketLimiter_NoEvictionWhenDisabled verifies deleteAfter <= 0 keeps keys.
+func TestBucketLimiter_NoEvictionWhenDisabled(t *testing.T) {
+	storage := newStorage()
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(10), 5), 0, storage)
+	t.Cleanup(func() { _ = bl.Close() })
+
+	bl.GetOrAdd("k")
+	time.Sleep(50 * time.Millisecond)
+	_, ok := storage.Load("k")
+	assert.True(t, ok, "eviction disabled: key must remain")
+}
+
+// TestBucketLimiter_GetOrAdd_Concurrent verifies concurrent creation of the
+// same key yields a single shared instance (no TOCTOU duplicate).
 func TestBucketLimiter_GetOrAdd_Concurrent(t *testing.T) {
-	storage := NewInMemoryStorage()
-	baseLimiter := newTestBaseLimiter()
-	deleteAfter := 200 * time.Millisecond
-	bl := NewBucketLimiter(baseLimiter, deleteAfter, storage)
+	storage := newStorage()
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(10), 5), time.Second, storage)
+	t.Cleanup(func() { _ = bl.Close() })
 
-	key := "concurrent-key"
-	numGoroutines := 50
+	const numGoroutines = 100
+	results := make([]Limiter, numGoroutines)
 	var wg sync.WaitGroup
-	var firstLimiter Limiter
-	var mu sync.Mutex // Protect access to firstLimiter
-
 	wg.Add(numGoroutines)
-	for range numGoroutines {
+	for i := range numGoroutines {
 		go func() {
 			defer wg.Done()
-			limiter := bl.GetOrAdd(key)
-			assert.NotNil(t, limiter)
-
-			mu.Lock()
-			if firstLimiter == nil {
-				firstLimiter = limiter
-			} else {
-				// All subsequent calls should get the same instance until it's potentially deleted
-				assert.Same(t, firstLimiter, limiter, "Concurrent GetOrAdd should return the same instance")
-			}
-			mu.Unlock()
+			results[i] = bl.GetOrAdd("concurrent-key")
 		}()
 	}
 	wg.Wait()
 
-	// Verify it's still stored (or was stored at some point)
-	storedLimiter, ok := storage.Load(key)
-	assert.True(t, ok, "Limiter should be stored after concurrent access")
-	assert.Same(t, firstLimiter, storedLimiter, "Stored limiter should be the one returned by goroutines")
-
-	// Test deletion after concurrent access
-	time.Sleep(deleteAfter + 50*time.Millisecond)
-	_, ok = storage.Load(key)
-	assert.False(t, ok, "Limiter should be deleted after deleteAfter duration following concurrent access")
-}
-
-func TestBucketLimiter_ConcurrentAccess_One_Target(t *testing.T) {
-	limit := 5.0
-	burst := 5
-	deleteAfter := time.Second * 5
-
-	storage := NewInMemoryStorage()
-	baseLimiter := rate.NewLimiter(rate.Limit(limit), burst)
-
-	limiter := NewBucketLimiter(baseLimiter, deleteAfter, storage)
-	numRequests := 100
-	rateSeg := time.Second * 1
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	var wg sync.WaitGroup
-	wg.Add(numRequests)
-
-	go func() {
-		ticker := time.NewTicker(rateSeg)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				for i := range numRequests {
-					go func(who string, reqNum int) {
-						defer wg.Done()
-
-						lim := limiter.GetOrAdd(who)
-						if !lim.Allow() {
-							_, err := fmt.Printf("Request from %s is limited\n", who)
-							if err != nil {
-								t.Errorf("Failed to print message: %v", err)
-							}
-
-							return
-						}
-
-						request(t, who)
-					}("anonymous", i)
-				}
-
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	wg.Wait()
-}
-
-func TestBucketLimiter_ConcurrentAccess_Multiple_Targets(t *testing.T) {
-	limit := 5.0
-	burst := 5
-
-	deleteAfter := time.Second * 5
-	storage := NewInMemoryStorage()
-	baseLimiter := rate.NewLimiter(rate.Limit(limit), burst)
-
-	limiter := NewBucketLimiter(baseLimiter, deleteAfter, storage)
-
-	numRequests := 100
-	numTargets := 2
-
-	rateSeg := time.Second * 1
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	var wg sync.WaitGroup
-	wg.Add(numRequests * numTargets)
-
-	go func() {
-		ticker := time.NewTicker(rateSeg)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				for j := range numTargets {
-					for i := range numRequests {
-						go func(who string, reqNum int) {
-							defer wg.Done()
-
-							lim := limiter.GetOrAdd(who)
-							if !lim.Allow() {
-								_, err := fmt.Printf("Request from %s is limited\n", who)
-								if err != nil {
-									t.Errorf("Failed to print message: %v", err)
-								}
-
-								return
-							}
-
-							request(t, who)
-						}(fmt.Sprintf("anonymous-%d", j), i)
-					}
-				}
-
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	wg.Wait()
-}
-
-// Example_bucketLimiter demonstrates basic usage of the BucketLimiter.
-func ExampleBucketLimiter() {
-	// Create a storage (in-memory for this example)
-	storage := NewInMemoryStorage()
-
-	// Define the base rate limit: 5 requests per second with a burst of 3
-	baseLimiter := rate.NewLimiter(rate.Limit(5), 3)
-
-	// Create the BucketLimiter: limiters expire after 1 minute of inactivity
-	deleteAfter := 1 * time.Minute
-	bucketLimiter := NewBucketLimiter(baseLimiter, deleteAfter, storage)
-
-	// Simulate requests for different keys (e.g., user IDs, IP addresses)
-	keys := []string{"user-1", "user-2", "user-1", "user-3", "user-1", "user-2"}
-	ctx := context.Background()
-
-	var wg sync.WaitGroup
-	wg.Add(len(keys))
-
-	fmt.Println("Simulating requests...")
-
-	for i, key := range keys {
-		go func(k string, reqNum int) {
-			defer wg.Done()
-
-			// Get the specific limiter for this key
-			lim := bucketLimiter.GetOrAdd(k)
-
-			// Wait for permission according to the limit
-			err := lim.Wait(ctx)
-			if err != nil {
-				fmt.Printf("Request %d (%s): Error waiting for limiter: %v\n", reqNum+1, k, err)
-				return
-			}
-
-			// Process the request (simulated)
-			fmt.Printf("Request %d (%s): Processed\n", reqNum+1, k)
-			time.Sleep(50 * time.Millisecond) // Simulate work
-		}(key, i)
-		time.Sleep(100 * time.Millisecond) // Stagger requests slightly
+	stored, ok := storage.Load("concurrent-key")
+	require.True(t, ok)
+	for i, got := range results {
+		assert.Same(t, stored, got, "goroutine %d got a different instance", i)
 	}
-
-	wg.Wait()
-	fmt.Println("All simulations finished.")
-
-	// You can manually remove a limiter if needed
-	_ = bucketLimiter.Remove("user-3")
-	fmt.Println("Removed limiter for user-3.")
-
-	// Limiters for user-1 and user-2 will be automatically removed
-	// by the background cleanup goroutine after 'deleteAfter' duration
-	// if they are not accessed again.
-
-	// Output:
-	// Simulating requests...
-	// Request 1 (user-1): Processed
-	// Request 2 (user-2): Processed
-	// Request 3 (user-1): Processed
-	// Request 4 (user-3): Processed
-	// Request 5 (user-1): Processed
-	// Request 6 (user-2): Processed
-	// All simulations finished.
-	// Removed limiter for user-3.
 }
 
-// TestBucketLimiter_Wait demonstrates the Wait method behavior.
+// TestBucketLimiter_DistinctKeysConcurrent stresses many independent keys.
+func TestBucketLimiter_DistinctKeysConcurrent(t *testing.T) {
+	storage := newStorage()
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(100), 10), time.Second, storage)
+	t.Cleanup(func() { _ = bl.Close() })
+
+	const numKeys = 200
+	var wg sync.WaitGroup
+	wg.Add(numKeys)
+	for k := range numKeys {
+		go func() {
+			defer wg.Done()
+			key := fmt.Sprintf("key-%d", k)
+			// Each key's first burst-worth of Allow() calls should all pass on
+			// its own fresh bucket.
+			lim := bl.GetOrAdd(key)
+			assert.True(t, lim.Allow(), "first request for %s should pass", key)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestBucketLimiter_Wait verifies Wait shapes traffic to the configured rate.
 func TestBucketLimiter_Wait(t *testing.T) {
-	storage := NewInMemoryStorage()
-	// Low limit for easier testing: 2 tokens/sec, burst 1
-	baseLimiter := rate.NewLimiter(rate.Limit(2), 1)
-	// Increase deleteAfter to be longer than the expected test duration (~1.5s)
-	// to prevent premature cleanup during the Wait calls.
-	deleteAfter := 3 * time.Second // Increased from 1 second
-	bl := NewBucketLimiter(baseLimiter, deleteAfter, storage)
-	key := "test-wait-key"
+	storage := newStorage()
+	// 2 tokens/sec, burst 1.
+	bl := NewBucketLimiter(NewRateLimiterFunc(rate.Limit(2), 1), 3*time.Second, storage)
+	t.Cleanup(func() { _ = bl.Close() })
+
+	limiter := bl.GetOrAdd("k")
 	ctx := context.Background()
 
-	limiter := bl.GetOrAdd(key)
-
-	numRequests := 4
-	var wg sync.WaitGroup
-	wg.Add(numRequests)
-	startTime := time.Now()
-
-	for i := range numRequests {
-		go func(reqNum int) {
-			defer wg.Done()
-			err := limiter.Wait(ctx)
-			assert.NoError(t, err, "Wait should not return an error in this test")
-			// Use t.Logf for logging within tests
-			t.Logf("Request %d processed at %v", reqNum, time.Since(startTime))
-		}(i)
-		// Add a small delay to stagger goroutine starts slightly,
-		// making timing less dependent on scheduler specifics.
-		time.Sleep(10 * time.Millisecond)
+	const numRequests = 4
+	start := time.Now()
+	for range numRequests {
+		require.NoError(t, limiter.Wait(ctx))
 	}
+	elapsed := time.Since(start)
 
-	wg.Wait()
-	elapsed := time.Since(startTime)
+	// Req 0 is immediate (burst), the next 3 wait ~0.5s each -> ~1.5s total.
+	// Use a lower bound only to avoid flakiness under race/CI scheduling.
+	assert.GreaterOrEqual(t, elapsed, 1200*time.Millisecond,
+		"Wait must shape traffic to roughly the configured rate")
+}
 
-	// Expected time:
-	// Req 0: ~0s (burst token)
-	// Req 1: ~0.5s (waits for token regeneration)
-	// Req 2: ~1.0s
-	// Req 3: ~1.5s
-	// Total time should be around 1.5 seconds for 4 requests at 2 req/sec with burst 1.
-	// Allow some buffer for scheduling delays.
-	minExpectedDuration := 1350 * time.Millisecond // Slightly less than 1.5s
-	maxExpectedDuration := 2100 * time.Millisecond // Allow more buffer
+// ExampleBucketLimiter demonstrates basic per-key usage.
+func ExampleBucketLimiter() {
+	storage := NewInMemoryStorage[string, Limiter]()
+	newLimiter := NewRateLimiterFunc(rate.Limit(5), 3) // 5 rps, burst 3
+	bl := NewBucketLimiter(newLimiter, time.Minute, storage)
+	defer bl.Close()
 
-	assert.GreaterOrEqual(t, elapsed, minExpectedDuration, "Elapsed time should be at least %v", minExpectedDuration)
-	assert.LessOrEqual(t, elapsed, maxExpectedDuration, "Elapsed time should be at most %v", maxExpectedDuration)
-
-	// Check cleanup works after waiting
-	// This check should now pass because deleteAfter (3s) > elapsed (~1.5s)
-	_, ok := storage.Load(key)
-	assert.True(t, ok, "Limiter should still be present immediately after Wait calls")
-
-	// Now wait for the actual deleteAfter duration to pass
-	time.Sleep(deleteAfter + 100*time.Millisecond)
-	_, ok = storage.Load(key)
-	assert.False(t, ok, "Limiter should be deleted after deleteAfter duration")
+	// user-A and user-B have independent buckets.
+	fmt.Println(bl.GetOrAdd("user-A").Allow())
+	fmt.Println(bl.GetOrAdd("user-B").Allow())
+	// Output:
+	// true
+	// true
 }

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,30 @@
+// Package ratelimiter provides a flexible, goroutine-safe rate limiter for Go,
+// built as a thin manager around the token-bucket implementation in
+// golang.org/x/time/rate.
+//
+// The central type is [BucketLimiter], a manager that hands out an independent
+// [Limiter] per key (for example a user ID or IP address). Each key gets its
+// own token bucket, so exhausting one key never affects another.
+//
+// Limiters are created lazily on first use and evicted after they have been
+// idle (not accessed) for a configurable duration. Eviction is performed by a
+// single background goroutine that is started when the manager is created and
+// stopped by [BucketLimiter.Close].
+//
+// Basic usage:
+//
+//	storage := ratelimiter.NewInMemoryStorage[string, ratelimiter.Limiter]()
+//	newLimiter := ratelimiter.NewRateLimiterFunc(rate.Limit(5), 10) // 5 rps, burst 10
+//	bl := ratelimiter.NewBucketLimiter(newLimiter, time.Minute, storage)
+//	defer bl.Close()
+//
+//	if bl.GetOrAdd("user-123").Allow() {
+//		// allowed
+//	}
+//
+// The [Storage] interface can be implemented to plug in a custom in-process
+// store. Note that the token-bucket state lives in memory inside each
+// *rate.Limiter, so this package targets single-process rate limiting.
+// Distributed rate limiting across multiple instances requires a different
+// algorithm and is out of scope.
+package ratelimiter

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,160 @@
+# Migration guide
+
+This release contains breaking API changes alongside a critical correctness
+fix. This guide maps every change to a concrete before/after so you can upgrade
+mechanically.
+
+> **Why the churn?** The previous version shared a single token bucket across
+> every key, so per-key limiting never actually worked. Fixing that required
+> constructing an independent limiter per key, which is the root of most of the
+> API changes below.
+
+## At a glance
+
+| Area                     | Before                                         | After                                                              |
+|--------------------------|------------------------------------------------|-------------------------------------------------------------------|
+| Store construction       | `NewInMemoryStorage()`                          | `NewInMemoryStorage[string, ratelimiter.Limiter]()`               |
+| Manager construction     | `NewBucketLimiter(baseLimiter, d, storage)`     | `NewBucketLimiter(newLimiterFunc, d, storage)`                    |
+| Building the limiter     | a single `*rate.Limiter` instance               | a `func() Limiter` factory (`NewRateLimiterFunc(limit, burst)`)   |
+| Lifecycle                | none                                            | `defer manager.Close()`                                           |
+| Getting a limiter        | `manager.GetOrAdd(key)`                         | `manager.GetOrAdd(key)` *(unchanged)*                            |
+| Calling on the manager   | `manager.Allow()` / `.Wait()` / `.Burst()`      | removed — use `manager.GetOrAdd(key).Allow()` etc.                |
+| Manual removal           | `err := manager.Remove(key)`                    | `manager.Remove(key)` *(no return value)*                        |
+| `Storage` interface      | non-generic, `Store/Load/Delete`                | generic `Storage[K, V]`, adds `LoadOrStore` and `Range`          |
+
+## 1. `NewInMemoryStorage` now requires type parameters
+
+```go
+// Before
+storage := ratelimiter.NewInMemoryStorage()
+
+// After
+storage := ratelimiter.NewInMemoryStorage[string, ratelimiter.Limiter]()
+```
+
+`K` is your key type (commonly `string`); `V` is `ratelimiter.Limiter`.
+
+## 2. `NewBucketLimiter` takes a factory, not a limiter instance
+
+A single `*rate.Limiter` cannot be shared across keys (that was the bug). Pass a
+factory that builds a fresh limiter per key instead. Use the `NewRateLimiterFunc`
+helper for the common case.
+
+```go
+// Before
+baseLimiter := rate.NewLimiter(rate.Limit(5), 10)
+manager := ratelimiter.NewBucketLimiter(baseLimiter, time.Minute, storage)
+
+// After
+newLimiter := ratelimiter.NewRateLimiterFunc(rate.Limit(5), 10) // 5 rps, burst 10
+manager := ratelimiter.NewBucketLimiter(newLimiter, time.Minute, storage)
+```
+
+If you need custom construction per key, pass your own factory:
+
+```go
+newLimiter := func() ratelimiter.Limiter {
+    return rate.NewLimiter(rate.Limit(5), 10)
+}
+```
+
+`K` is inferred from `storage`, so no explicit type arguments are needed on
+`NewBucketLimiter`.
+
+## 3. Call `Close()` to stop the eviction goroutine
+
+The manager now runs a single background sweeper for idle eviction. Stop it when
+you are done to avoid leaking a goroutine.
+
+```go
+manager := ratelimiter.NewBucketLimiter(newLimiter, time.Minute, storage)
+defer manager.Close()
+```
+
+(If you set `deleteAfter <= 0`, eviction is disabled and no goroutine is started;
+`Close()` is then a safe no-op.)
+
+## 4. The manager is no longer a `Limiter`
+
+`BucketLimiter` used to expose `Allow()`, `Wait()` and `Burst()` directly — but
+those operated on the shared bucket, which was the bug. They are removed. Always
+go through a key:
+
+```go
+// Before (operated on the shared bucket — incorrect)
+if manager.Allow() { ... }
+
+// After (per-key)
+if manager.GetOrAdd(key).Allow() { ... }
+
+err := manager.GetOrAdd(key).Wait(ctx)
+burst := manager.GetOrAdd(key).Burst()
+```
+
+## 5. `Remove` no longer returns an error
+
+```go
+// Before
+if err := manager.Remove(key); err != nil { ... }
+
+// After
+manager.Remove(key)
+```
+
+## 6. Custom `Storage` implementations
+
+If you implemented `Storage` yourself, it is now generic and has two additional
+methods:
+
+```go
+type Storage[K comparable, V any] interface {
+    Store(key K, value V)
+    Load(key K) (value V, ok bool)
+    LoadOrStore(key K, value V) (actual V, loaded bool) // new — must be atomic
+    Delete(key K)
+    Range(f func(key K, value V) bool)                  // new
+}
+```
+
+- `LoadOrStore` must be **atomic** so concurrent callers racing on the same key
+  all receive the same stored value; the manager relies on this to avoid
+  creating duplicate limiters.
+- `Range` is used by the manager only indirectly; implement it to iterate the
+  current entries (return `false` from `f` to stop early).
+
+## Behavioral changes (no code change required)
+
+- **Per-key isolation now works.** Distinct keys have independent buckets;
+  exhausting one key no longer throttles others. If you had worked around the old
+  shared-bucket behavior, you can remove those workarounds.
+- **Eviction is now idle-based.** A key is evicted after `deleteAfter` of *no
+  use*, and every `GetOrAdd` refreshes its timer — previously a key was deleted a
+  fixed duration after *creation* regardless of activity. Ensure your
+  `deleteAfter` reflects "idle time", not "total lifetime".
+
+## Full before/after example
+
+```go
+// Before
+storage := ratelimiter.NewInMemoryStorage()
+baseLimiter := rate.NewLimiter(rate.Limit(5), 10)
+manager := ratelimiter.NewBucketLimiter(baseLimiter, time.Minute, storage)
+
+if manager.GetOrAdd("user-123").Allow() {
+    // ...
+}
+_ = manager.Remove("user-123")
+```
+
+```go
+// After
+storage := ratelimiter.NewInMemoryStorage[string, ratelimiter.Limiter]()
+newLimiter := ratelimiter.NewRateLimiterFunc(rate.Limit(5), 10)
+manager := ratelimiter.NewBucketLimiter(newLimiter, time.Minute, storage)
+defer manager.Close()
+
+if manager.GetOrAdd("user-123").Allow() {
+    // ...
+}
+manager.Remove("user-123")
+```

--- a/docs/TOKEN_BUCKET.md
+++ b/docs/TOKEN_BUCKET.md
@@ -1,0 +1,262 @@
+# Rate limiting with the token bucket algorithm
+
+This document explains the algorithm behind `ratelimiter`, how to choose its
+parameters, and how those parameters behave in practice. It is written to be
+useful even if you have never implemented a rate limiter before.
+
+- [Why rate limit at all?](#why-rate-limit-at-all)
+- [The token bucket, intuitively](#the-token-bucket-intuitively)
+- [The two parameters: rate and burst](#the-two-parameters-rate-and-burst)
+- [How the math works](#how-the-math-works)
+- [Allow vs. Wait vs. Reserve](#allow-vs-wait-vs-reserve)
+- [Choosing parameters](#choosing-parameters)
+- [Per-key limiting](#per-key-limiting)
+- [Eviction of idle keys](#eviction-of-idle-keys)
+- [HTTP response headers](#http-response-headers)
+- [Comparison with other algorithms](#comparison-with-other-algorithms)
+- [Single-process vs. distributed](#single-process-vs-distributed)
+- [Further reading](#further-reading)
+
+## Why rate limit at all?
+
+A rate limiter caps how often an operation may happen. It is the tool you reach
+for to:
+
+- **Protect a resource** — a database, an upstream API, a payment provider — from
+  being overwhelmed.
+- **Enforce fairness** — stop a single user, IP, or API key from consuming a
+  shared service's whole capacity.
+- **Contain abuse and cost** — throttle brute-force login attempts, scrapers, or
+  runaway retries; keep metered-API spend predictable.
+- **Smooth traffic** — turn spiky arrivals into a steady stream your backend can
+  actually handle.
+
+The hard part is allowing *normal* bursts (users legitimately click twice, retry
+once) while still enforcing a sustainable long-run average. The token bucket is
+popular precisely because it expresses both in two numbers.
+
+## The token bucket, intuitively
+
+Picture a bucket that holds tokens:
+
+```
+        tokens drip in at a fixed rate (r per second)
+                     │
+                     ▼
+              ┌───────────────┐
+              │   ● ● ● ●      │  ← capacity = burst (b)
+              │   ● ●          │     the bucket never holds more than b
+              └───────┬───────┘
+                      │  each request removes 1 token
+                      ▼
+             request allowed  (token available)
+             request limited  (bucket empty)
+```
+
+Rules:
+
+1. Tokens are added to the bucket at a steady **rate** `r` (tokens per second).
+2. The bucket can hold at most **burst** `b` tokens. Extra drips overflow and are
+   lost — the bucket never exceeds its capacity.
+3. Each request tries to take 1 token. If one is available, the request is
+   **allowed** and a token is removed. If the bucket is empty, the request is
+   **limited** (rejected, or made to wait).
+
+Two consequences fall out of these rules:
+
+- **Long-run average** is capped at `r` requests per second — you cannot take
+  tokens faster than they drip in.
+- **Short bursts** up to `b` are allowed instantly, because a full or partly
+  full bucket lets several requests through back-to-back before it empties.
+
+## The two parameters: rate and burst
+
+`ratelimiter` builds each key's bucket with
+[`golang.org/x/time/rate`](https://pkg.go.dev/golang.org/x/time/rate) via
+`NewRateLimiterFunc(limit, burst)`:
+
+| Parameter | Type        | Meaning                                                        |
+|-----------|-------------|----------------------------------------------------------------|
+| `limit`   | `rate.Limit`| Refill rate in **tokens per second**. The sustained average.   |
+| `burst`   | `int`       | Bucket **capacity**. The largest instantaneous burst allowed.  |
+
+Helpers for expressing the rate:
+
+```go
+rate.Limit(5)        // 5 tokens per second
+rate.Every(200*time.Millisecond) // 1 token every 200ms == 5/sec
+rate.Inf             // unlimited (every request allowed)
+```
+
+> Note: `burst` is the maximum tokens available *at a single instant*, not a
+> per-second quota. "10 requests per second" is `limit = 10`; how bursty that is
+> allowed to be is a separate choice you make with `burst`.
+
+## How the math works
+
+The bucket does not literally run a background ticker per request. `x/time/rate`
+computes the token count lazily from elapsed time, which is exact and cheap:
+
+- Tokens available at time `t`:
+  `tokens(t) = min(b, tokens(t₀) + r · (t − t₀))`
+  where `t₀` is the last time the bucket was updated.
+- A request for 1 token at time `t` succeeds immediately if `tokens(t) ≥ 1`.
+- If not, the time until a token is available is
+  `wait = (1 − tokens(t)) / r`.
+
+Worked example — `limit = 2/sec`, `burst = 1`, requests arrive as fast as
+possible:
+
+| Request | Time    | Tokens before | Result   | Notes                         |
+|---------|---------|---------------|----------|-------------------------------|
+| 1       | 0.00s   | 1.0           | allowed  | consumes the single burst token |
+| 2       | 0.00s   | 0.0           | limited  | must wait `1/2 s`             |
+| 3       | 0.50s   | 1.0           | allowed  | one token refilled            |
+| 4       | 1.00s   | 1.0           | allowed  | steady state: one every 0.5s  |
+
+With `burst = 5` instead, the first **five** requests at `t = 0` are allowed
+(the full bucket), then the rate settles to one every 0.5s.
+
+## Allow vs. Wait vs. Reserve
+
+The same bucket can be consumed three ways. `ratelimiter.Limiter` exposes the
+first two; the underlying `*rate.Limiter` also offers `Reserve`.
+
+- **`Allow() bool`** — non-blocking. Returns `true` and consumes a token if one
+  is available, else `false`. Use it to **drop** work on overload (HTTP 429,
+  shed load). This is the common choice for request throttling.
+- **`Wait(ctx) error`** — blocking. Sleeps until a token is available or `ctx`
+  is cancelled/expired. Use it to **shape** work — a background job or client
+  that should slow down rather than fail. Beware unbounded goroutine buildup if
+  arrivals persistently exceed `r`; always pass a `ctx` with a deadline.
+- **`Reserve()` / `ReserveN()`** (on `*rate.Limiter`) — reserves a token and
+  tells you the `Delay()` until it becomes valid, without blocking. This is what
+  the middleware example uses to compute an accurate `Retry-After`. If you decide
+  not to proceed, call `reservation.Cancel()` to return the token.
+
+## Choosing parameters
+
+Start from the resource you are protecting and the behavior you want:
+
+- **Sustained rate (`limit`)** = the average throughput the protected resource
+  can handle indefinitely, divided across the number of keys you expect. If your
+  database tolerates 1,000 writes/sec and you limit per user, `limit` is the
+  per-user share you are willing to grant.
+- **Burst (`burst`)** = how much slack you allow for legitimate spikes. Rules of
+  thumb:
+  - `burst = 1` → strict spacing, essentially "no two requests closer than `1/r`
+    seconds". Harsh on normal users (double-clicks fail).
+  - `burst` = a few seconds' worth of rate (`≈ r · 2..5`) → absorbs normal
+    spikes while still capping the average. A good default for user-facing APIs.
+  - Large `burst` → very permissive spikes; only the long-run average is
+    enforced. Use when spikiness is expected and the resource can absorb it.
+
+Concrete starting points:
+
+| Use case                          | `limit`             | `burst` |
+|-----------------------------------|---------------------|---------|
+| Public API per API key            | `rate.Limit(10)`    | `20`    |
+| Login / auth endpoint per IP      | `rate.Every(time.Second)` (`1/s`) | `5` |
+| Expensive report generation/user  | `rate.Every(time.Minute)` (`1/min`) | `2` |
+| Internal service-to-service       | `rate.Limit(1000)`  | `200`   |
+
+Then load-test and adjust. The two knobs are independent: raise `burst` for
+friendlier spikes, raise `limit` for more sustained throughput.
+
+## Per-key limiting
+
+`BucketLimiter` keeps a **separate bucket per key** (a user ID, API key, or IP).
+`GetOrAdd(key)` returns that key's limiter, creating it with your factory on
+first use:
+
+```go
+storage := ratelimiter.NewInMemoryStorage[string, ratelimiter.Limiter]()
+manager := ratelimiter.NewBucketLimiter(
+    ratelimiter.NewRateLimiterFunc(rate.Limit(5), 10),
+    time.Minute,
+    storage,
+)
+defer manager.Close()
+
+if manager.GetOrAdd(userID).Allow() {
+    // ... handle request
+}
+```
+
+Because each key has its own bucket, one client draining its budget has **no
+effect** on any other client. Creation is atomic: if two goroutines ask for the
+same brand-new key simultaneously, both receive the same limiter instance.
+
+## Eviction of idle keys
+
+An unbounded number of keys (for example, per-IP limiting exposed to the
+internet) would leak memory if buckets lived forever. `BucketLimiter` tracks
+each key's last-use time and a single background goroutine evicts keys idle for
+longer than `deleteAfter`:
+
+- Every access through `GetOrAdd` refreshes the key's idle timer, so **actively
+  used keys are never evicted**.
+- The sweep runs every `deleteAfter/2` by default (tune with
+  `WithSweepInterval`). Worst case, a key is removed up to ~1.5·`deleteAfter`
+  after its last use.
+- Set `deleteAfter <= 0` to disable eviction entirely — only for **bounded** key
+  spaces, where the total number of distinct keys is small and known.
+- Call `Close()` when done to stop the goroutine.
+
+Eviction resets state: after a key is removed, the next `GetOrAdd` builds a fresh
+full bucket. Choose `deleteAfter` comfortably longer than the window over which
+you want the limit to hold (e.g. minutes, not milliseconds) so a client cannot
+reset its own bucket by pausing briefly.
+
+## HTTP response headers
+
+Well-behaved HTTP clients can self-throttle if you tell them the state of their
+bucket. The middleware example sets, on every response:
+
+| Header                | Meaning                                                    |
+|-----------------------|------------------------------------------------------------|
+| `RateLimit-Limit`     | Bucket capacity (`burst`) for this client.                 |
+| `RateLimit-Remaining` | Whole tokens currently available.                          |
+| `RateLimit-Reset`     | Seconds until a token is expected to be available.         |
+| `Retry-After`         | On `429` only: seconds to wait before retrying.            |
+
+The `RateLimit-*` names follow the IETF draft
+[*RateLimit header fields for HTTP*](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/);
+the example also emits the legacy `X-RateLimit-*` variants for older clients.
+`Retry-After` is standardized in
+[RFC 9110 §10.2.3](https://www.rfc-editor.org/rfc/rfc9110#section-10.2.3) and is
+computed from the reservation delay so it is accurate rather than a guess.
+
+## Comparison with other algorithms
+
+| Algorithm            | Bursts | Memory/key | Notes                                           |
+|----------------------|--------|------------|-------------------------------------------------|
+| **Token bucket**     | Yes    | O(1)       | This library. Smooth average + bounded burst.   |
+| Leaky bucket         | No     | O(1)       | Enforces a strictly constant output rate.       |
+| Fixed window counter | Spiky  | O(1)       | Simple, but allows 2× burst at window edges.    |
+| Sliding window log   | Exact  | O(requests)| Precise but stores every timestamp.             |
+| Sliding window count | Good   | O(1)       | Approximates the log cheaply; common in Redis.  |
+
+The token bucket is the usual default: O(1) per key, allows configurable bursts,
+and enforces a clean long-run average without the edge-of-window doubling that
+fixed windows suffer from.
+
+## Single-process vs. distributed
+
+This library limits within a **single process**: the token state lives in memory
+inside each `*rate.Limiter`. If you run N instances behind a load balancer, each
+enforces the limit independently, so the effective global limit is up to N·`r`.
+
+For a *global* limit shared across instances you need a distributed algorithm
+(commonly a sliding-window or token-bucket script in Redis, or a dedicated rate
+limiting service). That is deliberately out of scope here — the `Storage`
+interface exists to plug in custom **in-process** stores (e.g. a size-bounded
+LRU), not to synchronize token state across machines.
+
+## Further reading
+
+- `golang.org/x/time/rate` package docs — <https://pkg.go.dev/golang.org/x/time/rate>
+- Token bucket — <https://en.wikipedia.org/wiki/Token_bucket>
+- Leaky bucket — <https://en.wikipedia.org/wiki/Leaky_bucket>
+- IETF RateLimit header fields — <https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/>
+- RFC 9110 (HTTP semantics, `Retry-After`, `429`) — <https://www.rfc-editor.org/rfc/rfc9110>

--- a/examples/key/main.go
+++ b/examples/key/main.go
@@ -1,4 +1,11 @@
-package main // Changed from 'example' to 'main' to make it runnable
+// Command key demonstrates the basics of per-key rate limiting: creating a
+// manager, fetching a key's limiter, and observing the token bucket allow and
+// then refill over time.
+//
+// Run it:
+//
+//	go run ./examples/key -limit 1 -burst 3
+package main
 
 import (
 	"flag"
@@ -10,51 +17,40 @@ import (
 )
 
 func main() {
-	limit := flag.Int("limit", 1, "Rate limit (requests per second)")
-	burst := flag.Int("burst", 1, "Burst size")
-	deleteAfter := flag.Duration("deleteAfter", 5*time.Second, "Duration after which the limiter will be deleted if not used")
+	limit := flag.Int("limit", 1, "sustained rate limit (requests per second)")
+	burst := flag.Int("burst", 3, "burst size (bucket capacity)")
+	deleteAfter := flag.Duration("deleteAfter", 5*time.Second, "idle duration after which an unused limiter is evicted")
 	flag.Parse()
 
-	// Example usage of the BucketLimiter
-	// Create a storage system
-	storage := ratelimiter.NewInMemoryStorage()
+	// 1. A store that keeps one Limiter per key.
+	storage := ratelimiter.NewInMemoryStorage[string, ratelimiter.Limiter]()
 
-	// Create a base rate limiter
-	baseLimiter := rate.NewLimiter(rate.Limit(float64(*limit)), *burst)
+	// 2. A factory that builds an independent token bucket for each new key.
+	newLimiter := ratelimiter.NewRateLimiterFunc(rate.Limit(float64(*limit)), *burst)
 
-	// Create a bucket limiter with a deleteAfter duration of 5 seconds
-	// This means inactive limiters will be removed after 5 seconds
-	bucketLimiter := ratelimiter.NewBucketLimiter(baseLimiter, *deleteAfter, storage)
+	// 3. The manager. Close() stops its background eviction goroutine.
+	manager := ratelimiter.NewBucketLimiter(newLimiter, *deleteAfter, storage)
+	defer manager.Close()
 
-	// Get or add a limiter for a specific key
-	key := "user123"
-
-	// Simulate multiple requests
-	for i := range 15 {
-		userLimiter := bucketLimiter.GetOrAdd(key)
-
-		// Check if the user is allowed to make a request
-		if userLimiter.Allow() {
-			fmt.Printf("Request %d for key '%s': Allowed\n", i+1, key)
-			// Process the request
-		} else {
-			fmt.Printf("Request %d for key '%s': Rejected (Rate Limit Exceeded)\n", i+1, key)
-			// Reject the request
-		}
-
-		time.Sleep(500 * time.Millisecond) // Wait between requests
+	// Two distinct keys prove isolation: "alice" draining her bucket does not
+	// affect "bob".
+	fmt.Println("== independent buckets ==")
+	for range *burst + 2 {
+		fmt.Printf("alice: %-8v bob: %v\n",
+			allow(manager, "alice"), allow(manager, "bob"))
 	}
 
-	// Wait for cleanup to potentially happen (longer than deleteAfter)
-	fmt.Println()
-	fmt.Println("Waiting for potential cleanup...")
-	time.Sleep(6 * time.Second)
-
-	// Try again after cleanup, a new limiter should be created if deleted
-	userLimiter := bucketLimiter.GetOrAdd(key)
-	if userLimiter.Allow() {
-		fmt.Printf("Request after cleanup for key '%s': Allowed\n", key)
-	} else {
-		fmt.Printf("Request after cleanup for key '%s': Rejected\n", key)
+	// Watch a single key refill over time at the configured rate.
+	fmt.Println("\n== refill over time (alice) ==")
+	for i := range 6 {
+		fmt.Printf("t=%ds  alice: %v\n", i, allow(manager, "alice"))
+		time.Sleep(time.Second)
 	}
+}
+
+func allow(m *ratelimiter.BucketLimiter[string], key string) string {
+	if m.GetOrAdd(key).Allow() {
+		return "allowed"
+	}
+	return "limited"
 }

--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -1,33 +1,97 @@
+// Command middleware demonstrates using ratelimiter as per-client HTTP
+// middleware, including standard rate-limit response headers.
+//
+// It limits requests per client IP address. Each IP gets its own token bucket,
+// so one noisy client cannot exhaust the budget of others. When a client is
+// throttled the handler responds 429 Too Many Requests with an accurate
+// Retry-After header, and every response carries RateLimit-* headers so
+// well-behaved clients can self-throttle.
+//
+// Run it:
+//
+//	go run ./examples/middleware -limit 2 -burst 1
 package main
 
 import (
 	"flag"
 	"fmt"
+	"math"
+	"net"
 	"net/http"
-	"strings"
+	"strconv"
 	"time"
 
 	"github.com/slashdevops/ratelimiter"
 	"golang.org/x/time/rate"
 )
 
-// Middleware is a function that wraps an http.Handler to provide additional functionality
+// Middleware wraps an http.Handler with additional behavior.
 type Middleware func(http.Handler) http.Handler
 
-// ThenFunc wraps an http.HandlerFunc with a middleware
+// ThenFunc adapts an http.HandlerFunc through the middleware.
 func (m Middleware) ThenFunc(h http.HandlerFunc) http.Handler {
 	return m(http.HandlerFunc(h))
 }
 
-// IPRateLimiter is a middleware that limits the number of requests from a single IP address
-func IPRateLimiter(limiter *ratelimiter.BucketLimiter) Middleware {
+// clientIP extracts the client IP from the request. It uses net.SplitHostPort
+// so it works for both IPv4 (1.2.3.4:5678) and IPv6 ([::1]:5678) remote
+// addresses. In production behind a proxy or load balancer you would instead
+// parse a trusted X-Forwarded-For / Forwarded header.
+func clientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// IPRateLimiter returns middleware that rate limits requests per client IP.
+//
+// On every request it consults the client's own token bucket via Reserve,
+// which lets us both decide whether to allow the request and compute an
+// accurate Retry-After when we don't. The following response headers are set:
+//
+//   - RateLimit-Limit:     bucket capacity (burst) for this client.
+//   - RateLimit-Remaining: whole tokens currently available.
+//   - RateLimit-Reset:     seconds until the bucket is expected to have a token.
+//   - Retry-After:         (429 only) seconds the client should wait before retrying.
+//
+// The RateLimit-* names follow the IETF "RateLimit header fields for HTTP"
+// draft; the widely-deployed X-RateLimit-* variants are set too for
+// compatibility with older clients.
+func IPRateLimiter(manager *ratelimiter.BucketLimiter[string]) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ip := strings.Split(r.RemoteAddr, ":")[0]
+			ip := clientIP(r)
+			limiter := manager.GetOrAdd(ip)
 
-			lim := limiter.GetOrAdd(ip)
-			if !lim.Allow() {
-				http.Error(w, fmt.Sprintf("too many requests from ip address %s", ip), http.StatusTooManyRequests)
+			// The manager hands out *rate.Limiter values via NewRateLimiterFunc,
+			// so we can use the richer Reserve API for accurate headers.
+			rl, ok := limiter.(*rate.Limiter)
+			if !ok {
+				// Fallback for custom Limiter implementations: Allow-only.
+				if !limiter.Allow() {
+					http.Error(w, "too many requests", http.StatusTooManyRequests)
+					return
+				}
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			now := time.Now()
+			res := rl.ReserveN(now, 1)
+			delay := res.DelayFrom(now)
+
+			setHeader(w, "RateLimit-Limit", strconv.Itoa(rl.Burst()))
+			setHeader(w, "RateLimit-Remaining", strconv.Itoa(int(rl.TokensAt(now))))
+			setHeader(w, "RateLimit-Reset", strconv.Itoa(secondsCeil(delay)))
+
+			if !res.OK() || delay > 0 {
+				// Not allowed right now: give the token back and reject.
+				res.Cancel()
+				retryAfter := max(secondsCeil(delay), 1)
+				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+				http.Error(w, fmt.Sprintf("too many requests from %s", ip), http.StatusTooManyRequests)
 				return
 			}
 
@@ -36,40 +100,44 @@ func IPRateLimiter(limiter *ratelimiter.BucketLimiter) Middleware {
 	}
 }
 
-func main() {
-	limit := flag.Int("limit", 2, "Rate limit (requests per second)")
-	burst := flag.Int("burst", 1, "Burst size")
-	deleteAfter := flag.Duration("deleteAfter", 5*time.Second, "Duration after which the limiter will be deleted if not used")
-	numberOfRequests := flag.Int("numberOfRequests", 30, "Number of requests to send")
-	waitBetweenRequests := flag.Duration("waitBetweenRequests", 100*time.Millisecond, "Wait time between requests")
+// setHeader writes both the IETF draft name and the legacy X- prefixed name.
+func setHeader(w http.ResponseWriter, name, value string) {
+	w.Header().Set(name, value)
+	w.Header().Set("X-"+name, value)
+}
 
+// secondsCeil rounds a duration up to whole seconds (never negative).
+func secondsCeil(d time.Duration) int {
+	if d <= 0 {
+		return 0
+	}
+	return int(math.Ceil(d.Seconds()))
+}
+
+func main() {
+	limit := flag.Int("limit", 2, "sustained rate limit (requests per second)")
+	burst := flag.Int("burst", 1, "burst size (bucket capacity)")
+	deleteAfter := flag.Duration("deleteAfter", 5*time.Second, "idle duration after which a client's limiter is evicted")
+	numberOfRequests := flag.Int("numberOfRequests", 30, "number of demo requests to send")
+	waitBetweenRequests := flag.Duration("waitBetweenRequests", 100*time.Millisecond, "wait time between demo requests")
 	flag.Parse()
 
-	// Create a storage system
-	storage := ratelimiter.NewInMemoryStorage()
+	storage := ratelimiter.NewInMemoryStorage[string, ratelimiter.Limiter]()
+	newLimiter := ratelimiter.NewRateLimiterFunc(rate.Limit(float64(*limit)), *burst)
+	manager := ratelimiter.NewBucketLimiter(newLimiter, *deleteAfter, storage)
+	defer manager.Close()
 
-	// Create a base rate limiter
-	baseLimiter := rate.NewLimiter(rate.Limit(float64(*limit)), *burst)
-
-	// Create a bucket limiter with a deleteAfter duration of 5 seconds
-	bucketLimiter := ratelimiter.NewBucketLimiter(baseLimiter, *deleteAfter, storage)
-
-	// Create a new HTTP server
 	mux := http.NewServeMux()
-
-	// Register the rate limiting middleware
-	mux.Handle("GET /", IPRateLimiter(bucketLimiter).ThenFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "Hello, world without limit!")
+	mux.Handle("GET /", IPRateLimiter(manager).ThenFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, world!")
 	}))
 
-	// go routine doing request
+	// Demo client that fires requests at the local server.
 	go func() {
-		// wait until the server is up
 		fmt.Println("Waiting for server to start...")
-		time.Sleep(2 * time.Second)
+		time.Sleep(500 * time.Millisecond)
 
 		for range *numberOfRequests {
-
 			resp, err := http.Get("http://localhost:8080/")
 			if err != nil {
 				fmt.Println("Error:", err)
@@ -77,19 +145,17 @@ func main() {
 			}
 			resp.Body.Close()
 
-			if resp.StatusCode == http.StatusOK {
-				fmt.Println("Request allowed")
-			} else {
-				fmt.Println("Request rejected:", resp.Status)
+			switch resp.StatusCode {
+			case http.StatusOK:
+				fmt.Printf("allowed  (remaining=%s)\n", resp.Header.Get("RateLimit-Remaining"))
+			default:
+				fmt.Printf("rejected %s (retry-after=%s)\n", resp.Status, resp.Header.Get("Retry-After"))
 			}
-			time.Sleep(*waitBetweenRequests) // Wait between requests
+			time.Sleep(*waitBetweenRequests)
 		}
-
-		fmt.Println()
-		fmt.Println("Finished sending requests, press Ctrl+C to stop the server")
+		fmt.Println("\nFinished sending requests, press Ctrl+C to stop the server")
 	}()
 
-	// Start the server
 	fmt.Println("Starting server on :8080...")
 	if err := http.ListenAndServe(":8080", mux); err != nil {
 		fmt.Println("Error starting server:", err)

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
-golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/limiter.go
+++ b/limiter.go
@@ -2,10 +2,24 @@ package ratelimiter
 
 import "context"
 
-// Limiter interface defines the methods for a rate limiter
-// Must be implemented by any rate limiting algorithm
+// Limiter is the minimal contract a per-key rate limiter must satisfy. It is a
+// subset of the methods on *golang.org/x/time/rate.Limiter, so a standard
+// *rate.Limiter satisfies Limiter directly.
+//
+// Implementations MUST be safe for concurrent use by multiple goroutines.
 type Limiter interface {
+	// Burst returns the maximum number of tokens that can be consumed in a
+	// single instant (the bucket capacity). A burst of zero allows no events,
+	// unless the rate is Inf.
 	Burst() int
+
+	// Allow reports whether one event may happen now, consuming a token if so.
+	// It never blocks and is the right choice for drop-on-limit workloads such
+	// as HTTP request throttling.
 	Allow() bool
+
+	// Wait blocks until a token is available or ctx is done, returning ctx's
+	// error in the latter case. Use it to shape (delay) work rather than drop
+	// it.
 	Wait(ctx context.Context) (err error)
 }

--- a/memory_store.go
+++ b/memory_store.go
@@ -2,25 +2,51 @@ package ratelimiter
 
 import "sync"
 
-type InMemoryStorage struct {
+// InMemoryStorage is a goroutine-safe, map-backed implementation of
+// [Storage] built on top of [sync.Map]. It keeps every value in process
+// memory and never evicts on its own; eviction of idle entries is driven by
+// the owning [BucketLimiter].
+type InMemoryStorage[K comparable, V any] struct {
 	data sync.Map
 }
 
-func NewInMemoryStorage() *InMemoryStorage {
-	return &InMemoryStorage{
-		data: sync.Map{},
-	}
+// NewInMemoryStorage returns a ready-to-use, empty [InMemoryStorage].
+//
+//	storage := ratelimiter.NewInMemoryStorage[string, ratelimiter.Limiter]()
+func NewInMemoryStorage[K comparable, V any]() *InMemoryStorage[K, V] {
+	return &InMemoryStorage[K, V]{}
 }
 
-func (s *InMemoryStorage) Store(key any, value any) {
+// Store implements [Storage].
+func (s *InMemoryStorage[K, V]) Store(key K, value V) {
 	s.data.Store(key, value)
 }
 
-func (s *InMemoryStorage) Delete(key any) {
+// Load implements [Storage].
+func (s *InMemoryStorage[K, V]) Load(key K) (value V, ok bool) {
+	v, ok := s.data.Load(key)
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	return v.(V), true
+}
+
+// LoadOrStore implements [Storage]. It is atomic: concurrent callers racing on
+// the same key all receive the same stored value.
+func (s *InMemoryStorage[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	v, loaded := s.data.LoadOrStore(key, value)
+	return v.(V), loaded
+}
+
+// Delete implements [Storage].
+func (s *InMemoryStorage[K, V]) Delete(key K) {
 	s.data.Delete(key)
 }
 
-func (s *InMemoryStorage) Load(key any) (value any, ok bool) {
-	value, ok = s.data.Load(key)
-	return
+// Range implements [Storage].
+func (s *InMemoryStorage[K, V]) Range(f func(key K, value V) bool) {
+	s.data.Range(func(k, v any) bool {
+		return f(k.(K), v.(V))
+	})
 }

--- a/memory_store_test.go
+++ b/memory_store_test.go
@@ -1,0 +1,83 @@
+package ratelimiter
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryStorage_StoreLoadDelete(t *testing.T) {
+	s := NewInMemoryStorage[string, int]()
+
+	_, ok := s.Load("missing")
+	assert.False(t, ok, "load of absent key returns zero, false")
+
+	s.Store("a", 1)
+	v, ok := s.Load("a")
+	require.True(t, ok)
+	assert.Equal(t, 1, v)
+
+	s.Delete("a")
+	_, ok = s.Load("a")
+	assert.False(t, ok)
+}
+
+func TestInMemoryStorage_LoadOrStore(t *testing.T) {
+	s := NewInMemoryStorage[string, int]()
+
+	actual, loaded := s.LoadOrStore("k", 10)
+	assert.False(t, loaded)
+	assert.Equal(t, 10, actual)
+
+	actual, loaded = s.LoadOrStore("k", 20)
+	assert.True(t, loaded, "second call should load the existing value")
+	assert.Equal(t, 10, actual, "existing value wins")
+}
+
+// TestInMemoryStorage_LoadOrStore_Atomic verifies concurrent racers converge on
+// a single stored value.
+func TestInMemoryStorage_LoadOrStore_Atomic(t *testing.T) {
+	s := NewInMemoryStorage[string, int]()
+
+	const n = 100
+	results := make([]int, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func() {
+			defer wg.Done()
+			actual, _ := s.LoadOrStore("k", i)
+			results[i] = actual
+		}()
+	}
+	wg.Wait()
+
+	winner := results[0]
+	for i, got := range results {
+		assert.Equal(t, winner, got, "goroutine %d disagreed on the stored value", i)
+	}
+}
+
+func TestInMemoryStorage_Range(t *testing.T) {
+	s := NewInMemoryStorage[string, int]()
+	s.Store("a", 1)
+	s.Store("b", 2)
+	s.Store("c", 3)
+
+	seen := map[string]int{}
+	s.Range(func(k string, v int) bool {
+		seen[k] = v
+		return true
+	})
+	assert.Equal(t, map[string]int{"a": 1, "b": 2, "c": 3}, seen)
+
+	// Early stop after the first element.
+	count := 0
+	s.Range(func(string, int) bool {
+		count++
+		return false
+	})
+	assert.Equal(t, 1, count, "returning false stops iteration")
+}

--- a/rate.go
+++ b/rate.go
@@ -1,0 +1,20 @@
+package ratelimiter
+
+import "golang.org/x/time/rate"
+
+// NewRateLimiterFunc returns a factory suitable for [NewBucketLimiter] that
+// builds an independent *golang.org/x/time/rate.Limiter for each new key.
+//
+//   - limit is the sustained refill rate in tokens per second. Use
+//     rate.Every(d) to express "one token every d", or rate.Inf for no limit.
+//   - burst is the bucket capacity: the maximum number of tokens available in
+//     a single instant (and thus the largest momentary burst allowed).
+//
+// Example: 5 requests per second, absorbing bursts of up to 10:
+//
+//	newLimiter := ratelimiter.NewRateLimiterFunc(rate.Limit(5), 10)
+func NewRateLimiterFunc(limit rate.Limit, burst int) func() Limiter {
+	return func() Limiter {
+		return rate.NewLimiter(limit, burst)
+	}
+}

--- a/storage.go
+++ b/storage.go
@@ -1,9 +1,32 @@
 package ratelimiter
 
-// Storage interface defines the methods for a storage system
-// Must be implemented by any storage system used in the rate limiter
-type Storage interface {
-	Store(key any, value any)
-	Delete(key any)
-	Load(key any) (value any, ok bool)
+// Storage is the pluggable backing store used by [BucketLimiter] to keep the
+// per-key [Limiter] instances. The default implementation is
+// [InMemoryStorage], but any in-process store (for example a size-bounded LRU)
+// can be supplied by implementing this interface.
+//
+// Implementations MUST be safe for concurrent use by multiple goroutines.
+//
+// K is the key type (commonly string) and V is the stored value type
+// (commonly [Limiter]).
+type Storage[K comparable, V any] interface {
+	// Store unconditionally sets value for key.
+	Store(key K, value V)
+
+	// Load returns the value stored for key, and whether it was present.
+	Load(key K) (value V, ok bool)
+
+	// LoadOrStore returns the existing value for key if present; otherwise it
+	// stores and returns the given value. loaded reports whether the value was
+	// already present. It MUST be atomic so that concurrent callers racing on
+	// the same key all observe the same stored value.
+	LoadOrStore(key K, value V) (actual V, loaded bool)
+
+	// Delete removes key from the store. Deleting an absent key is a no-op.
+	Delete(key K)
+
+	// Range calls f sequentially for each key/value currently present. If f
+	// returns false, Range stops iterating. The store may be modified during
+	// iteration; the observed set of keys is a best-effort snapshot.
+	Range(f func(key K, value V) bool)
 }


### PR DESCRIPTION
## Summary

This PR fixes a **critical correctness bug** and modernizes the library.

The headline bug: **every key shared a single underlying `rate.Limiter`**, so all keys drained one token bucket — the core promise of per-key rate limiting did not actually hold. A new regression test (`TestBucketLimiter_PerKeyIsolation`) fails on the old code and passes now.

## What changed

### Correctness
- **Per-key isolation:** `GetOrAdd` now builds an **independent** `Limiter` per key via a `func() Limiter` factory. One key exhausting its budget no longer affects others.
- **Atomic creation:** key creation uses `LoadOrStore`, fixing a TOCTOU race that could create duplicate limiters for the same key.
- **Correct eviction semantics + lifecycle:** replaced the per-key sleeping goroutine (which deleted after a fixed time from *creation*, leaked a goroutine per key, and reset active buckets) with a **single background sweeper** that evicts genuinely *idle* keys — the idle timer is refreshed on every access. Added `Close()` to stop it.

### API / best practices (Go 1.25)
- `Storage[K, V]` and `BucketLimiter[K]` are now **generic** for type safety.
- Added `NewRateLimiterFunc(limit, burst)` helper and `WithClock` / `WithSweepInterval` options.
- `Storage` gained `LoadOrStore` and `Range`.

### Examples & headers
- Middleware uses `net.SplitHostPort` (**IPv6-safe** client IP).
- Middleware sets accurate **`Retry-After`** (from the reservation delay) and **`RateLimit-Limit/Remaining/Reset`** headers (IETF draft names + legacy `X-RateLimit-*`).
- `examples/key` is a minimal demo of per-key isolation and refill over time.

### Docs & tests
- New [`docs/TOKEN_BUCKET.md`](docs/TOKEN_BUCKET.md): a thorough explanation of the token bucket algorithm, choosing `limit`/`burst`, `Allow` vs `Wait` vs `Reserve`, eviction, HTTP headers, algorithm comparison, and single-process vs distributed scope.
- Rewrote `README.md` and added package-level `doc.go`.
- Rewrote tests: isolation regression, **deterministic** eviction via an injected clock (de-flaked the old timing-bound `Wait` test), concurrency, storage, and benchmarks.

## Verification
- `go test -race ./...` — passing, **100% statement coverage**.
- `go vet ./...`, `gofmt` — clean.
- Both examples run; middleware verified end-to-end (200 with `RateLimit-*` headers → 429 with `Retry-After: 1`).

## ⚠️ Breaking changes
- `NewBucketLimiter` takes a `func() Limiter` factory instead of a `Limiter` instance.
- `Storage` and `BucketLimiter` are generic; `NewInMemoryStorage` requires type parameters (`NewInMemoryStorage[string, ratelimiter.Limiter]()`).
- `BucketLimiter` no longer implements `Limiter` — call `GetOrAdd(key)` to obtain one.
- `Remove` no longer returns an `error`.

## Scope note
This library limits **within a single process**. Global cross-instance limiting needs a distributed algorithm and remains out of scope; `Storage` is for custom *in-process* stores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)