### PR TITLE
chore: bump go directive to 1.25.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ sequenceDiagram
 go get github.com/slashdevops/ratelimiter
 ```
 
-Requires Go 1.25 or newer.
+Requires Go 1.25.2 or newer.
 
 ## Quick start
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/slashdevops/ratelimiter
 
-go 1.25.0
+go 1.25.2
 
 require golang.org/x/time v0.15.0


### PR DESCRIPTION
## Problem

CI fails when installing the `scc` code-statistics tool:

```
go install github.com/boyter/scc/v3@latest
go: github.com/boyter/scc/v3@v3.7.0 requires go >= 1.25.2 (running go 1.25.0; GOTOOLCHAIN=local)
```

Both [`.github/workflows/pr.yaml`](.github/workflows/pr.yaml) and [`.github/workflows/release.yml`](.github/workflows/release.yml) configure `actions/setup-go` with `go-version-file: ./go.mod`, so the provisioned toolchain follows the module's `go` directive. With the module pinned to `go 1.25.0`, `scc` v3.7.0 (which now requires Go ≥ 1.25.2) refuses to install.

## Fix

Bump the `go` directive in `go.mod` from `1.25.0` to `1.25.2` so `setup-go` provisions a toolchain that satisfies `scc`. The README's stated minimum is updated to match.

## Verification

```
go mod verify   # all modules verified
go build ./...  # ok
go vet ./...    # ok
go test ./...   # ok
```

No source or public API changes — only the minimum Go version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)