### PR TITLE
chore: bump go directive to 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ idle for a configurable duration.
   that have not been used for `deleteAfter`; active keys are kept alive. Stop it
   with `Close()`.
 - **Type-safe & generic** — `Storage[K, V]` and `BucketLimiter[K]` use Go
-  generics (Go 1.25+).
+  generics (Go 1.26+).
 - **Extensible** — implement the `Storage` interface for a custom in-process
   store, or the `Limiter` interface for a custom algorithm.
 - **HTTP middleware example** — with accurate `Retry-After` and `RateLimit-*`
@@ -114,7 +114,7 @@ sequenceDiagram
 go get github.com/slashdevops/ratelimiter
 ```
 
-Requires Go 1.25.2 or newer.
+Requires Go 1.26 or newer.
 
 ## Quick start
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/slashdevops/ratelimiter
 
-go 1.25.2
+go 1.26.0
 
 require golang.org/x/time v0.15.0


### PR DESCRIPTION
## Problem

CI fails installing the `go-test-coverage` tool ([run](https://github.com/slashdevops/ratelimiter/actions/runs/29154344390/job/86548900355)):

```
go install github.com/vladopajic/go-test-coverage/v2@latest
go: github.com/vladopajic/go-test-coverage/v2@v2.18.8 requires go >= 1.26 (running go 1.25.2; GOTOOLCHAIN=local)
Error: Process completed with exit code 1.
```

`actions/setup-go` is configured with `go-version-file: ./go.mod`, so the provisioned toolchain follows the module's `go` directive. With the module pinned to `go 1.25.2`, `go-test-coverage` v2.18.8 (which now requires Go ≥ 1.26) refuses to install.

## Fix

Bump the `go` directive in `go.mod` from `1.25.2` to `1.26.0`, and update the README's stated minimum to match.

## Verification

```
go mod verify   # all modules verified
go build ./...  # ok
go vet ./...    # ok
go test ./...   # ok
```

No source or public API changes — only the minimum Go version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)